### PR TITLE
[DJANGO_4.2_LIBRARY_DEPRECATIONS] Make django_translation_aliases work in django 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ matrix:
         - TOXENV=py37-2.1-cover,codecov
       python: '3.7'
     - env:
-        - TOXENV=py37-2.2-cover,codecov
-      python: '3.7'
+        - TOXENV=py38-3.2-cover,codecov
+      python: '3.8'
 before_install:
   - python --version
   - uname -a

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ To set up `django-translation-aliases` for local development:
 
    Now you can make your changes locally.
 
-4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <http://tox.readthedocs.io/en/latest/install.html>`_ one command::
+4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <https://tox.wiki/en/latest/installation.html>`_ one command::
 
     tox
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,8 @@ include CONTRIBUTING.rst
 include LICENSE
 include README.rst
 
-include tox.ini .travis.yml appveyor.yml
+include tox.ini .travis.yml appveyor.yml pyproject.toml
+
+include local-setup.sh
 
 global-exclude *.py[cod] __pycache__ *.so *.dylib

--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys
@@ -8,7 +10,6 @@ from os.path import abspath
 from os.path import dirname
 from os.path import exists
 from os.path import join
-
 
 if __name__ == "__main__":
     base_path = dirname(dirname(abspath(__file__)))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import os
 
-
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',

--- a/local-setup.sh
+++ b/local-setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+
+# curl https://pyenv.run | bash
+
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+
+exec "$SHELL"
+
+pyenv install 3.8 3.9 3.10
+pyenv global 3.8 3.9 3.10
+
+source ~/.bashrc

--- a/local-setup.sh
+++ b/local-setup.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
 
-# curl https://pyenv.run | bash
+curl https://pyenv.run | bash
 
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
 echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
 echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+source ~/.bashrc
 
 exec "$SHELL"
 
 pyenv install 3.8 3.9 3.10
 pyenv global 3.8 3.9 3.10
 
-source ~/.bashrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+target-version = ["py38", "py39", "py310"]
+include = '\.pyi?$'

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ line_length = 120
 known_first_party = django_translation_aliases
 default_section = THIRDPARTY
 forced_separate = test_django_translation_aliases
-not_skip = __init__.py
 skip = migrations
 
 
@@ -62,15 +61,10 @@ skip = migrations
 #  - can use as many you want
 
 python_versions =
-    py27
-    py36
-    py37
+    py38
 
 dependencies =
-    1.11: Django~=1.11.0
-    2.0: Django~=2.0.0 !python_versions[py27]
-    2.1: Django~=2.1.0 !python_versions[py27]
-    2.2: Django~=2.2.0 !python_versions[py27]
+    2.2: Django~=3.2 !python_versions[py38]
 
 coverage_flags =
    cover: true

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,13 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Django',
         'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.2',
         'Topic :: Utilities',
     ],
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,7 @@ from setuptools import setup
 
 
 def read(*names, **kwargs):
-    with io.open(
-        join(dirname(__file__), *names),
-        encoding=kwargs.get('encoding', 'utf8')
-    ) as fh:
+    with io.open(join(dirname(__file__), *names), encoding=kwargs.get('encoding', 'utf8')) as fh:
         return fh.read()
 
 
@@ -28,9 +25,10 @@ setup(
     version='0.1.0',
     license='BSD 3-Clause License',
     description='A small library which adds "translate" and "blocktranslate" templatetags as and modified makemessages to work with them.',
-    long_description='%s\n%s' % (
+    long_description='%s\n%s'
+    % (
         re.compile('^.. start-badges.*^.. end-badges', re.M | re.S).sub('', read('README.rst')),
-        re.sub(':[a-z]+:`~?(.*?)`', r'``\1``', read('CHANGELOG.rst'))
+        re.sub(':[a-z]+:`~?(.*?)`', r'``\1``', read('CHANGELOG.rst')),
     ),
     author='Mike Hansen',
     author_email='mike@rover.com',
@@ -65,8 +63,6 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     python_requires='>=3.8',
-    install_requires=[
-        'Django>=3.2', 'six'
-    ],
-    extras_require={}
+    install_requires=['Django>=3.2', 'six'],
+    extras_require={},
 )

--- a/setup.py
+++ b/setup.py
@@ -49,19 +49,11 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.2',
         'Topic :: Utilities',
     ],
     project_urls={
@@ -72,9 +64,9 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.8',
     install_requires=[
-        'Django>=1.11',
+        'Django>=3.2', 'six'
     ],
     extras_require={}
 )

--- a/src/django_translation_aliases/apps.py
+++ b/src/django_translation_aliases/apps.py
@@ -15,9 +15,7 @@ inline_re = re.compile(
     # Match the optional context part
     r"""(\s+.*context\s+((?:"[^"]*?")|(?:'[^']*?')))?\s*"""
 )
-block_re = re.compile(
-    r"""^\s*blocktrans(?:late)?(\s+.*context\s+((?:"[^"]*?")|(?:'[^']*?')))?(?:\s+|$)"""
-)
+block_re = re.compile(r"""^\s*blocktrans(?:late)?(\s+.*context\s+((?:"[^"]*?")|(?:'[^']*?')))?(?:\s+|$)""")
 endblock_re = re.compile(r"""^\s*endblocktrans(?:late)?$""")
 
 

--- a/src/django_translation_aliases/templatetags.py
+++ b/src/django_translation_aliases/templatetags.py
@@ -66,45 +66,31 @@ def do_block_translate(parser, token):
     while remaining_bits:
         option = remaining_bits.pop(0)
         if option in options:
-            raise TemplateSyntaxError(
-                "The %r option was specified more " "than once." % option
-            )
+            raise TemplateSyntaxError("The %r option was specified more " "than once." % option)
         if option == "with":
             value = token_kwargs(remaining_bits, parser, support_legacy=True)
             if not value:
-                raise TemplateSyntaxError(
-                    '"with" in %r tag needs at least ' "one keyword argument." % bits[0]
-                )
+                raise TemplateSyntaxError('"with" in %r tag needs at least ' "one keyword argument." % bits[0])
         elif option == "count":
             value = token_kwargs(remaining_bits, parser, support_legacy=True)
             if len(value) != 1:
-                raise TemplateSyntaxError(
-                    '"count" in %r tag expected exactly '
-                    "one keyword argument." % bits[0]
-                )
+                raise TemplateSyntaxError('"count" in %r tag expected exactly ' "one keyword argument." % bits[0])
         elif option == "context":
             try:
                 value = remaining_bits.pop(0)
                 value = parser.compile_filter(value)
             except Exception:
-                raise TemplateSyntaxError(
-                    '"context" in %r tag expected exactly one argument.' % bits[0]
-                )
+                raise TemplateSyntaxError('"context" in %r tag expected exactly one argument.' % bits[0])
         elif option == "trimmed":
             value = True
         elif option == "asvar":
             try:
                 value = remaining_bits.pop(0)
             except IndexError:
-                raise TemplateSyntaxError(
-                    "No argument provided to the '%s' tag for the asvar option."
-                    % bits[0]
-                )
+                raise TemplateSyntaxError("No argument provided to the '%s' tag for the asvar option." % bits[0])
             asvar = value
         else:
-            raise TemplateSyntaxError(
-                "Unknown argument for %r tag: %r." % (bits[0], option)
-            )
+            raise TemplateSyntaxError("Unknown argument for %r tag: %r." % (bits[0], option))
         options[option] = value
 
     if "count" in options:
@@ -129,9 +115,7 @@ def do_block_translate(parser, token):
             break
     if countervar and counter:
         if token.contents.strip() != "plural":
-            raise TemplateSyntaxError(
-                "%r doesn't allow other block tags inside it" % bits[0]
-            )
+            raise TemplateSyntaxError("%r doesn't allow other block tags inside it" % bits[0])
         while parser.tokens:
             token = parser.next_token()
             if token.token_type in (TokenType.VAR, TokenType.TEXT):
@@ -140,10 +124,7 @@ def do_block_translate(parser, token):
                 break
     end_tag_name = "end%s" % bits[0]
     if token.contents.strip() != end_tag_name:
-        raise TemplateSyntaxError(
-            "%r doesn't allow other block tags (seen %r) inside it"
-            % (bits[0], token.contents)
-        )
+        raise TemplateSyntaxError("%r doesn't allow other block tags (seen %r) inside it" % (bits[0], token.contents))
 
     return BlockTranslateNode(
         extra_context,

--- a/src/django_translation_aliases/templatetags.py
+++ b/src/django_translation_aliases/templatetags.py
@@ -9,7 +9,8 @@ from django.templatetags.i18n import BlockTranslateNode
 try:
     from django.template.base import TokenType
 except ImportError:
-    from django.template.base import TOKEN_TEXT, TOKEN_VAR
+    from django.template.base import TOKEN_TEXT
+    from django.template.base import TOKEN_VAR
 
     class TokenType:
         VAR = TOKEN_VAR

--- a/tests/base.py
+++ b/tests/base.py
@@ -35,9 +35,12 @@ def setup(templates, *args, **kwargs):
         templates.update(arg)
 
     loaders = [
-        ('django.template.loaders.cached.Loader', [
-            ('django.template.loaders.locmem.Loader', templates),
-        ]),
+        (
+            'django.template.loaders.cached.Loader',
+            [
+                ('django.template.loaders.locmem.Loader', templates),
+            ],
+        ),
     ]
 
     def decorator(func):
@@ -90,7 +93,7 @@ class POFileAssertionMixin(object):
         expected_value = re.escape(expected_value)
         return self.assertTrue(
             re.search('^%s %s' % (keyword, expected_value), haystack, re.MULTILINE),
-            'Could not find %(q)s%(n)s%(q)s in generated PO file' % {'n': needle, 'q': q}
+            'Could not find %(q)s%(n)s%(q)s in generated PO file' % {'n': needle, 'q': q},
         )
 
     def assertMsgId(self, msgid, haystack, use_quotes=True):

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,9 +6,8 @@ import tempfile
 
 from django.template.engine import Engine
 from django.test.utils import override_settings
-from django.utils._os import upath
 
-source_code_dir = os.path.dirname(upath(__file__))
+source_code_dir = os.path.dirname(__file__)
 
 
 def copytree(src, dst):
@@ -34,10 +33,6 @@ def setup(templates, *args, **kwargs):
 
     for arg in args:
         templates.update(arg)
-
-    # numerous tests make use of an inclusion tag
-    # add this in here for simplicity
-    templates["inclusion.html"] = "{{ result }}"
 
     loaders = [
         ('django.template.loaders.cached.Loader', [

--- a/tests/test_blocktranslate.py
+++ b/tests/test_blocktranslate.py
@@ -24,11 +24,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         output = self.engine.render_to_string("i18n03", {"anton": "Å"})
         self.assertEqual(output, "Å")
 
-    @setup(
-        {
-            "i18n04": "{% load i18n %}{% blocktranslate with berta=anton|lower %}{{ berta }}{% endblocktranslate %}"
-        }
-    )
+    @setup({"i18n04": "{% load i18n %}{% blocktranslate with berta=anton|lower %}{{ berta }}{% endblocktranslate %}"})
     def test_i18n04(self):
         """simple translation of a variable and filter"""
         output = self.engine.render_to_string("i18n04", {"anton": "Å"})
@@ -45,11 +41,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         output = self.engine.render_to_string("legacyi18n04", {"anton": "Å"})
         self.assertEqual(output, "å")
 
-    @setup(
-        {
-            "i18n05": "{% load i18n %}{% blocktranslate %}xxx{{ anton }}xxx{% endblocktranslate %}"
-        }
-    )
+    @setup({"i18n05": "{% load i18n %}{% blocktranslate %}xxx{{ anton }}xxx{% endblocktranslate %}"})
     def test_i18n05(self):
         """simple translation of a string with interpolation"""
         output = self.engine.render_to_string("i18n05", {"anton": "yyy"})
@@ -104,10 +96,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         self.assertEqual(output, "2 plural")
 
     @setup(
-        {
-            "i18n17": "{% load i18n %}"
-            "{% blocktranslate with berta=anton|escape %}{{ berta }}{% endblocktranslate %}"
-        }
+        {"i18n17": "{% load i18n %}" "{% blocktranslate with berta=anton|escape %}{{ berta }}{% endblocktranslate %}"}
     )
     def test_i18n17(self):
         """
@@ -169,9 +158,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         """
         translation of plural form with extra field in singular form (#13568)
         """
-        output = self.engine.render_to_string(
-            "i18n26", {"myextra_field": "test", "number": 1}
-        )
+        output = self.engine.render_to_string("i18n26", {"myextra_field": "test", "number": 1})
         self.assertEqual(output, "singular test")
 
     @setup(
@@ -182,9 +169,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         }
     )
     def test_legacyi18n26(self):
-        output = self.engine.render_to_string(
-            "legacyi18n26", {"myextra_field": "test", "number": 1}
-        )
+        output = self.engine.render_to_string("legacyi18n26", {"myextra_field": "test", "number": 1})
         self.assertEqual(output, "singular test")
 
     @setup(
@@ -198,9 +183,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         """translation of singular form in Russian (#14126)"""
         with translation.override("ru"):
             output = self.engine.render_to_string("i18n27", {"number": 1})
-        self.assertEqual(
-            output, "1 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442"
-        )
+        self.assertEqual(output, "1 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442")
 
     @setup(
         {
@@ -212,9 +195,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
     def test_legacyi18n27(self):
         with translation.override("ru"):
             output = self.engine.render_to_string("legacyi18n27", {"number": 1})
-        self.assertEqual(
-            output, "1 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442"
-        )
+        self.assertEqual(output, "1 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442")
 
     @setup(
         {
@@ -235,16 +216,12 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         }
     )
     def test_legacyi18n28(self):
-        output = self.engine.render_to_string(
-            "legacyi18n28", {"anton": "α", "berta": "β"}
-        )
+        output = self.engine.render_to_string("legacyi18n28", {"anton": "α", "berta": "β"})
         self.assertEqual(output, "α + β")
 
     # blocktranslate handling of variables which are not in the context.
     # this should work as if blocktranslate was not there (#19915)
-    @setup(
-        {"i18n34": "{% load i18n %}{% blocktranslate %}{{ missing }}{% endblocktranslate %}"}
-    )
+    @setup({"i18n34": "{% load i18n %}{% blocktranslate %}{{ missing }}{% endblocktranslate %}"})
     def test_i18n34(self):
         output = self.engine.render_to_string("i18n34")
         if self.engine.string_if_invalid:
@@ -252,11 +229,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         else:
             self.assertEqual(output, "")
 
-    @setup(
-        {
-            "i18n34_2": "{% load i18n %}{% blocktranslate with a='α' %}{{ missing }}{% endblocktranslate %}"
-        }
-    )
+    @setup({"i18n34_2": "{% load i18n %}{% blocktranslate with a='α' %}{{ missing }}{% endblocktranslate %}"})
     def test_i18n34_2(self):
         output = self.engine.render_to_string("i18n34_2")
         if self.engine.string_if_invalid:
@@ -264,11 +237,7 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         else:
             self.assertEqual(output, "")
 
-    @setup(
-        {
-            "i18n34_3": "{% load i18n %}{% blocktranslate with a=anton %}{{ missing }}{% endblocktranslate %}"
-        }
-    )
+    @setup({"i18n34_3": "{% load i18n %}{% blocktranslate with a=anton %}{{ missing }}{% endblocktranslate %}"})
     def test_i18n34_3(self):
         output = self.engine.render_to_string("i18n34_3", {"anton": "\xce\xb1"})
         if self.engine.string_if_invalid:
@@ -340,37 +309,27 @@ class I18nBlockTranslateTagTests(SimpleTestCase):
         output = self.engine.render_to_string("template")
         self.assertEqual(output, "%s")
 
-    @setup(
-        {
-            "template": "{% load i18n %}{% blocktranslate %}{% block b %} {% endblock %}{% endblocktranslate %}"
-        }
-    )
+    @setup({"template": "{% load i18n %}{% blocktranslate %}{% block b %} {% endblock %}{% endblocktranslate %}"})
     def test_with_block(self):
         msg = switch_on_version(
             "'blocktranslate' doesn't allow other block tags (seen 'block b') inside it",
-            "'blocktranslate' doesn't allow other block tags (seen u'block b') inside it"
+            "'blocktranslate' doesn't allow other block tags (seen u'block b') inside it",
         )
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string("template")
 
     @setup(
-        {
-            "template": "{% load i18n %}{% blocktranslate %}{% for b in [1, 2, 3] %} {% endfor %}{% endblocktranslate %}"
-        }
+        {"template": "{% load i18n %}{% blocktranslate %}{% for b in [1, 2, 3] %} {% endfor %}{% endblocktranslate %}"}
     )
     def test_with_for(self):
         msg = switch_on_version(
             "'blocktranslate' doesn't allow other block tags (seen 'for b in [1, 2, 3]') inside it",
-            "'blocktranslate' doesn't allow other block tags (seen u'for b in [1, 2, 3]') inside it"
+            "'blocktranslate' doesn't allow other block tags (seen u'for b in [1, 2, 3]') inside it",
         )
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string("template")
 
-    @setup(
-        {
-            "template": "{% load i18n %}{% blocktranslate with foo=bar with %}{{ foo }}{% endblocktranslate %}"
-        }
-    )
+    @setup({"template": "{% load i18n %}{% blocktranslate with foo=bar with %}{{ foo }}{% endblocktranslate %}"})
     def test_variable_twice(self):
         msg = switch_on_version(
             "The 'with' option was specified more than once",

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -7,13 +7,13 @@ import time
 import warnings
 from unittest import skipUnless
 
+import six
 from django.core import management
 from django.core.management.utils import find_command
 from django.test import SimpleTestCase
-from django.utils import six
-from django.utils.encoding import force_text
-from django.utils.six import StringIO
+from django.utils.encoding import force_str
 from django.utils.translation import TranslatorCommentWarning
+from six import StringIO
 
 from .base import POFileAssertionMixin
 from .base import RunInTmpDirMixin
@@ -53,7 +53,7 @@ class ExtractorTests(POFileAssertionMixin, RunInTmpDirMixin, SimpleTestCase):
 
     def _assertPoLocComment(self, assert_presence, po_filename, line_number, *comment_parts):
         with open(po_filename, 'r') as fp:
-            po_contents = force_text(fp.read())
+            po_contents = force_str(fp.read())
         if os.name == 'nt':
             # #: .\path\to\file.html:123
             cwd_prefix = '%s%s' % (os.curdir, os.sep)
@@ -79,7 +79,7 @@ class ExtractorTests(POFileAssertionMixin, RunInTmpDirMixin, SimpleTestCase):
     def _get_token_line_number(self, path, token):
         with open(path) as f:
             for line, content in enumerate(f, 1):
-                if token in force_text(content):
+                if token in force_str(content):
                     return line
         self.fail("The token '%s' could not be found in %s, please check the test config" % (token, path))
 
@@ -125,7 +125,7 @@ class BasicExtractorTests(ExtractorTests):
         management.call_command('makemessages', locale=[LOCALE], verbosity=0)
         self.assertTrue(os.path.exists(self.PO_FILE))
         with open(self.PO_FILE, 'r') as fp:
-            po_contents = force_text(fp.read())
+            po_contents = force_str(fp.read())
             # should not be trimmed
             self.assertNotMsgId('Text with a few line breaks.', po_contents)
             # should be trimmed
@@ -142,7 +142,7 @@ class BasicExtractorTests(ExtractorTests):
         management.call_command('makemessages', locale=[LOCALE], verbosity=0)
         self.assertTrue(os.path.exists(self.PO_FILE))
         with open(self.PO_FILE, 'r') as fp:
-            po_contents = force_text(fp.read())
+            po_contents = force_str(fp.read())
             # {% translate %}
             self.assertIn('msgctxt "Special translate context #1"', po_contents)
             self.assertMsgId("Translatable literal #7a", po_contents)
@@ -172,7 +172,7 @@ class BasicExtractorTests(ExtractorTests):
         management.call_command('makemessages', locale=[LOCALE], verbosity=0)
         self.assertTrue(os.path.exists(self.PO_FILE))
         with open(self.PO_FILE, 'r') as fp:
-            po_contents = force_text(fp.read())
+            po_contents = force_str(fp.read())
             # {% translate %}
             self.assertIn('msgctxt "Context wrapped in double quotes"', po_contents)
             self.assertIn('msgctxt "Context wrapped in single quotes"', po_contents)
@@ -212,7 +212,7 @@ class BasicExtractorTests(ExtractorTests):
         # Now test .po file contents
         self.assertTrue(os.path.exists(self.PO_FILE))
         with open(self.PO_FILE, 'r') as fp:
-            po_contents = force_text(fp.read())
+            po_contents = force_str(fp.read())
 
             self.assertMsgId('Translatable literal #9a', po_contents)
             self.assertNotIn('ignored comment #1', po_contents)

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -195,19 +195,19 @@ class BasicExtractorTests(ExtractorTests):
                 str(ws[0].message),
                 r"The translator-targeted comment 'Translators: ignored i18n "
                 r"comment #1' \(file templates[/\\]comments.thtml, line 4\) "
-                r"was ignored, because it wasn't the last item on the line\."
+                r"was ignored, because it wasn't the last item on the line\.",
             )
             self.assertRegex(
                 str(ws[1].message),
                 r"The translator-targeted comment 'Translators: ignored i18n "
                 r"comment #3' \(file templates[/\\]comments.thtml, line 6\) "
-                r"was ignored, because it wasn't the last item on the line\."
+                r"was ignored, because it wasn't the last item on the line\.",
             )
             self.assertRegex(
                 str(ws[2].message),
                 r"The translator-targeted comment 'Translators: ignored i18n "
                 r"comment #4' \(file templates[/\\]comments.thtml, line 8\) "
-                r"was ignored, because it wasn't the last item on the line\."
+                r"was ignored, because it wasn't the last item on the line\.",
             )
         # Now test .po file contents
         self.assertTrue(os.path.exists(self.PO_FILE))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,19 +18,13 @@ class TranslationAliasesTests(SimpleTestCase):
         return Engine(loaders=loaders, libraries={"i18n": "django.templatetags.i18n"})
 
     def test_translate(self):
-        engine = self.get_engine(
-            {"t": '{% load i18n %}{% translate "Page not found" %}'}
-        )
+        engine = self.get_engine({"t": '{% load i18n %}{% translate "Page not found" %}'})
         with translation.override("de"):
             output = engine.render_to_string("t")
         self.assertEqual(output, "Seite nicht gefunden")
 
     def test_blocktranslate(self):
-        engine = self.get_engine(
-            {
-                "t": "{% load i18n %}{% blocktranslate %}Page not found{% endblocktranslate %}"
-            }
-        )
+        engine = self.get_engine({"t": "{% load i18n %}{% blocktranslate %}Page not found{% endblocktranslate %}"})
         with translation.override("de"):
             output = engine.render_to_string("t")
         self.assertEqual(output, "Seite nicht gefunden")

--- a/tox.ini
+++ b/tox.ini
@@ -38,11 +38,13 @@ deps =
     readme-renderer
     pygments
     isort
+    black
 skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 src tests setup.py
+    black -S src tests setup.py
     isort --verbose --check-only --diff src tests setup.py
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,20 +3,12 @@ envlist =
     clean,
     check,
     docs,
-    py27-1.11-cover,
-    py36-1.11-cover,
-    py36-2.0-cover,
-    py36-2.1-cover,
-    py36-2.2-cover,
-    py37-1.11-cover,
-    py37-2.0-cover,
-    py37-2.1-cover,
-    py37-2.2-cover,
+    py{38,39,310}-{3.2,4.2}-cover
     report
 
 [testenv]
 basepython =
-    {docs,spell}: {env:TOXPYTHON:python3.6}
+    {docs,spell}: {env:TOXPYTHON:python3.8}
     {bootstrap,clean,check,report,codecov}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
@@ -26,10 +18,9 @@ passenv =
 deps =
     pytest
     pytest-django
-    pytest-travis-fold
     pytest-cov
 commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv --ignore=src}
+    ./local-setup.py && {posargs:pytest --cov --cov-report=term-missing -vv --ignore=src}
 
 [testenv:bootstrap]
 deps =
@@ -52,7 +43,7 @@ commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --verbose --check-only --diff --recursive src tests setup.py
+    isort --verbose --check-only --diff src tests setup.py
 
 
 [testenv:spell]
@@ -94,8 +85,8 @@ commands = coverage erase
 skip_install = true
 deps = coverage
 
-[testenv:py27-1.11-cover]
-basepython = {env:TOXPYTHON:python2.7}
+[testenv:py38-3.2-cover]
+basepython = {env:TOXPYTHON:python3.8}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -104,10 +95,10 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
-    Django~=1.11.0
+    Django~=3.2
 
-[testenv:py36-1.11-cover]
-basepython = {env:TOXPYTHON:python3.6}
+[testenv:py39-3.2-cover]
+basepython = {env:TOXPYTHON:python3.9}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -116,10 +107,10 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
-    Django~=1.11.0
+    Django~=3.2
 
-[testenv:py36-2.0-cover]
-basepython = {env:TOXPYTHON:python3.6}
+[testenv:py310-3.2-cover]
+basepython = {env:TOXPYTHON:python3.10}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -128,10 +119,10 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
-    Django~=2.0.0
+    Django~=3.2
 
-[testenv:py36-2.1-cover]
-basepython = {env:TOXPYTHON:python3.6}
+[testenv:py38-4.2-cover]
+basepython = {env:TOXPYTHON:python3.8}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -140,10 +131,10 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
-    Django~=2.1.0
+    Django~=4.2
 
-[testenv:py36-2.2-cover]
-basepython = {env:TOXPYTHON:python3.6}
+[testenv:py39-4.2-cover]
+basepython = {env:TOXPYTHON:python3.9}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -152,10 +143,10 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
-    Django~=2.2.0
+    Django~=4.2
 
-[testenv:py37-1.11-cover]
-basepython = {env:TOXPYTHON:python3.7}
+[testenv:py310-4.2-cover]
+basepython = {env:TOXPYTHON:python3.10}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -164,40 +155,4 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
-    Django~=1.11.0
-
-[testenv:py37-2.0-cover]
-basepython = {env:TOXPYTHON:python3.7}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv}
-deps =
-    {[testenv]deps}
-    pytest-cov
-    Django~=2.0.0
-
-[testenv:py37-2.1-cover]
-basepython = {env:TOXPYTHON:python3.7}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv}
-deps =
-    {[testenv]deps}
-    pytest-cov
-    Django~=2.1.0
-
-[testenv:py37-2.2-cover]
-basepython = {env:TOXPYTHON:python3.7}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv}
-deps =
-    {[testenv]deps}
-    pytest-cov
-    Django~=2.2.0
+    Django~=4.2


### PR DESCRIPTION
# What is the reason for this pull request?
This PR  ensures the library runs with django 3.2 and 4.2,  preparing everything to start solving django 4.x deprecation warnings.

This pr adds black so is better if we first review the first commit which adds the checks and needed changes for the 3.2 and 4.2 versions of django and then we check the changes made by black